### PR TITLE
Ensure DnsApi sessions are properly closed

### DIFF
--- a/src/nic_api/__init__.py
+++ b/src/nic_api/__init__.py
@@ -749,3 +749,7 @@ class DnsApi(object):
                 "Failed to rollback changes:\n{}".format(response.text)
             )
         logger.info("Changes are rolled back")
+
+    def close(self):
+        self._session.close()
+        logger.info("Closed OAuth2Session session")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -13,3 +13,5 @@ def test_oauthfail():
     except Exception as err:
         assert isinstance(err, DnsApiException)
         assert str(err) in ("(invalid_client) ", "(unauthorized_client) ")
+    finally:
+        api.close()


### PR DESCRIPTION
This PR adds an explicit `close()` method to `DnsApi` and ensures it is called in the tests after `DnsApi` instances are used

Previously, the underlying `OAuth2Session.Session` could remain open, potentially leaking connections.

The issue was identified during an ongoing research project.